### PR TITLE
Files in $FLASK_APP/static files not included in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ cython_debug/
 
 # static files generated from Django application using `collectstatic`
 media
-static
+# static


### PR DESCRIPTION
Changing of .gitignore file that stops flask from serving files in the $FLASK_APP/static directory.
See https://flask.palletsprojects.com/en/1.1.x/quickstart/#static-files for more info.